### PR TITLE
修复技能BUG

### DIFF
--- a/workspace/CardFantasyCore/src/cfvbaibai/cardfantasy/data/CardData.xml
+++ b/workspace/CardFantasyCore/src/cfvbaibai/cardfantasy/data/CardData.xml
@@ -996,7 +996,7 @@
     <Card id="1594" name="美味厨娘" wikiId="" race="王国" speed="4" star="5" cost="18" incrCost="2" at="320" hp="1460" incrAT="43" incrHP="35">
         <Skill type="爱心料理" level="0" unlock="0" />
         <Skill type="不动" level="0" unlock="5"  />
-        <Skill type="生命符文" level="0" unlock="10" />
+        <Skill type="生命符文" level="4" unlock="10" />
     </Card>
     <Card id="1595" name="血色玫瑰" wikiId="" race="王国" speed="3" star="5" cost="18" incrCost="2" at="410" hp="1580" incrAT="45" incrHP="45">
         <Skill type="召唤玫瑰剑士" level="0" unlock="0" />

--- a/workspace/CardFantasyCore/src/cfvbaibai/cardfantasy/data/SkillType.java
+++ b/workspace/CardFantasyCore/src/cfvbaibai/cardfantasy/data/SkillType.java
@@ -360,8 +360,10 @@ public enum SkillType {
     召唤炮灰("", 0, 0, SkillTag.召唤, SkillTag.不可洗炼),
     召唤花舞剑士("", 0, 0, SkillTag.召唤, SkillTag.不可洗炼),
     召唤玫瑰甜心("", 0, 0, SkillTag.召唤, SkillTag.不可洗炼),
-    突击军势("", 0, 0, SkillTag.召唤, SkillTag.不可洗炼),
-    召唤玫瑰剑士("",SkillType.召唤花舞剑士,0, SkillType.召唤玫瑰甜心,0, SkillTag.不可洗炼),
+    召唤伍长("", 0, 0, SkillTag.召唤, SkillTag.不可洗炼),
+    召唤兵长("", 0, 0, SkillTag.召唤, SkillTag.不可洗炼),
+    突击军势("", SkillType.召唤伍长,0, SkillType.召唤兵长,0, SkillTag.不可洗炼,SkillTag.召唤),
+    召唤玫瑰剑士("",SkillType.召唤花舞剑士,0, SkillType.召唤玫瑰甜心,0, SkillTag.不可洗炼,SkillTag.召唤),
 
 
     圣光洗礼("", 0, 0, SkillTag.抗免疫, SkillTag.不可洗炼, SkillTag.魔王无效, SkillTag.魔族天赋),

--- a/workspace/CardFantasyCore/src/cfvbaibai/cardfantasy/engine/SkillResolver.java
+++ b/workspace/CardFantasyCore/src/cfvbaibai/cardfantasy/engine/SkillResolver.java
@@ -348,8 +348,13 @@ public class SkillResolver {
             } else if (skillUseInfo.getType() == SkillType.爱之召唤) {
                 Summon.apply(this, skillUseInfo, attacker, SummonType.Random, 2,
                         "爱之使者", "森林丘比特", "占卜少女", "爱神");
+            } else if (skillUseInfo.getType() == SkillType.召唤伍长) {
+                Summon.apply(this, skillUseInfo, attacker, SummonType.Normal, 1, "巅峰伍长");
+            } else if (skillUseInfo.getType() == SkillType.召唤兵长) {
+                Summon.apply(this, skillUseInfo, attacker, SummonType.Normal, 1,  "巅峰兵长");
             } else if (skillUseInfo.getType() == SkillType.突击军势) {
-                Summon.apply(this, skillUseInfo, attacker, SummonType.Normal, 2, "巅峰伍长", "巅峰兵长");
+                Summon.apply(this, skillUseInfo.getAttachedUseInfo1(), attacker, SummonType.Normal, 1, "巅峰伍长");
+                Summon.apply(this, skillUseInfo.getAttachedUseInfo2(), attacker, SummonType.Normal, 1,  "巅峰兵长");
             } else if (skillUseInfo.getType() == SkillType.连营) {
                 Summon.apply(this, skillUseInfo.getAttachedUseInfo1(), attacker, SummonType.Normal, 2, "炮灰", "炮灰");
                 MagicMark.apply(this, skillUseInfo.getAttachedUseInfo2(), attacker, defender, -1);

--- a/workspace/CardFantasyCore/src/cfvbaibai/cardfantasy/engine/skill/Overdraw.java
+++ b/workspace/CardFantasyCore/src/cfvbaibai/cardfantasy/engine/skill/Overdraw.java
@@ -21,7 +21,7 @@ public final class Overdraw {
         ui.useSkill(attacker, skill, true);
         ui.adjustAT(attacker, attacker, adjAT, skill);
         attacker.addEffect(new SkillEffect(SkillEffectType.ATTACK_CHANGE, skillUseInfo, adjAT, true));
-        ui.attackCard(attacker, attacker, skill, adjAT);
+        ui.attackCard(attacker, attacker, skill, adjHP);
         resolver.resolveDeathSkills(attacker, attacker, skill, resolver.applyDamage(attacker, attacker, skill, adjHP));
     }
 }

--- a/workspace/CardFantasyCore/src/cfvbaibai/cardfantasy/engine/skill/Summon.java
+++ b/workspace/CardFantasyCore/src/cfvbaibai/cardfantasy/engine/skill/Summon.java
@@ -18,7 +18,7 @@ public class Summon {
         }
         // 镜像不能再次发动镜像
         if (summoner.isSummonedMinion() && skillUseInfo.getType() == SkillType.镜像
-                || summoner.isSummonedMinion() && skillUseInfo.getType() == SkillType.镜魔) {
+                || summoner.isSummonedMinion() && skillUseInfo.getType() == SkillType.镜魔 || summoner.isSummonedMinion() && skillUseInfo.getType() == SkillType.九转禁术) {
             for(CardStatusItem item : summoner.getStatus().getAllItems())
             {
                 if(item.getType()==CardStatusType.召唤){

--- a/workspace/mkhx/WebContent/views/news.jsp
+++ b/workspace/mkhx/WebContent/views/news.jsp
@@ -36,6 +36,13 @@
             <div data-role="collapsible" data-collapsed="false" data-mini="true">
                 <h3>更新日志</h3>
                 <ul class="news-content">
+                    <li>2017-07-06: <x>欢笑，清风，波波，林知兀，布萨龙等</x><ul>
+                        <li>修复技能【过载】文字显示BUG</li>
+                        <li>修复技能【巅峰军曹】召唤技能没有分开的BUG</li>
+                        <li>修复【美味厨娘】的【生命符文】技能未添加的BUG</li>
+                        <li>修复【血色玫瑰】可被【夺魂】BUG</li>
+                        <li>修复【九命猫神】【镜像】重复发动的BUG</li>
+                    </ul></li>
                     <li>2017-07-04: <x>欢笑，清风，波波，林知兀，布萨龙等</x><ul>
                         <li>添加符文【背水】</li>
                         <li>觉醒卡牌【九命猫神】</li>


### PR DESCRIPTION
修复技能【过载】文字显示BUG，修复技能【巅峰军曹】召唤技能没有分开的BUG，修复【美味厨娘】的【生命符文】技能未添加的BUG，修复【血色玫瑰】可被【夺魂】BUG,修复【九命猫神】【镜像】重复发动的BUG.